### PR TITLE
Refactor evaluation script into CLI

### DIFF
--- a/gemini_eval.py
+++ b/gemini_eval.py
@@ -1,15 +1,13 @@
+import argparse
+import os
+import sys
+
 import vertexai
 import pandas as pd
 from vertexai.evaluation import EvalTask, PointwiseMetric, PointwiseMetricPromptTemplate
 from google.cloud import aiplatform
 from utilities.print_average import get_average
 import csv
-
-PROJECT_ID = "model-eval-463217"
-
-vertexai.init(
-    project=PROJECT_ID
-)
 
 custom_text_quality = PointwiseMetric(
     metric="custom_text-quality",
@@ -71,26 +69,84 @@ responses = [
     """,
 ]
 
-eval_dataset = pd.read_csv("eval_dataset.csv")
-file_name = "eval_results.csv"
 
-eval_task = EvalTask(
-    dataset=eval_dataset,
-    metrics=[custom_text_quality],
-    experiment="myexperiment"
-)
+def main(dataset_path: str, project_id: str, results_path: str) -> None:
+    """Run evaluation on a dataset and store the results.
 
-pointwise_result = eval_task.evaluate()
+    Args:
+        dataset_path: Path to the CSV dataset file.
+        project_id: Google Cloud project identifier used for Vertex AI.
+        results_path: Destination path for the evaluation results CSV.
+    """
 
-print(pointwise_result.metrics_table)
+    if not os.path.isfile(dataset_path):
+        raise FileNotFoundError(f"Dataset not found: {dataset_path}")
 
-with open(file_name, "w") as f:
-    f.write(pointwise_result.metrics_table.to_csv(index=False))
+    try:
+        vertexai.init(project=project_id)
+    except Exception as exc:  # pragma: no cover - depends on external service
+        raise RuntimeError(
+            f"Could not initialize Vertex AI for project '{project_id}': {exc}"
+        ) from exc
 
-aiplatform.ExperimentRun(
-    run_name=pointwise_result.metadata["experiment_run"],
-    experiment = pointwise_result.metadata["experiment"],
-).delete()
+    eval_dataset = pd.read_csv(dataset_path)
 
-print(f"The average score is: {round(get_average(), 2)}")
+    eval_task = EvalTask(
+        dataset=eval_dataset,
+        metrics=[custom_text_quality],
+        experiment="myexperiment",
+    )
+
+    pointwise_result = eval_task.evaluate()
+    print(pointwise_result.metrics_table)
+
+    try:
+        with open(results_path, "w") as f:
+            f.write(pointwise_result.metrics_table.to_csv(index=False))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not write results to {results_path}: {exc}"
+        ) from exc
+
+    aiplatform.ExperimentRun(
+        run_name=pointwise_result.metadata["experiment_run"],
+        experiment=pointwise_result.metadata["experiment"],
+    ).delete()
+
+    print(f"The average score is: {round(get_average(), 2)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Evaluate model responses using Vertex AI",
+    )
+    parser.add_argument(
+        "--dataset",
+        dest="dataset_path",
+        default=os.getenv("DATASET_PATH", "eval_dataset.csv"),
+        help="Path to the evaluation dataset CSV",
+    )
+    parser.add_argument(
+        "--project",
+        dest="project_id",
+        default=os.getenv("PROJECT_ID"),
+        help="Google Cloud project ID",
+    )
+    parser.add_argument(
+        "--results",
+        dest="results_path",
+        default=os.getenv("RESULTS_PATH", "eval_results.csv"),
+        help="File path to write evaluation results",
+    )
+
+    args = parser.parse_args()
+
+    if not args.project_id:
+        parser.error("A project ID must be provided via --project or PROJECT_ID")
+
+    try:
+        main(args.dataset_path, args.project_id, args.results_path)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 


### PR DESCRIPTION
## Summary
- add `main()` function to parameterize dataset path, project id, and results path
- accept CLI arguments or environment variables via argparse
- improve error handling for missing files or invalid Vertex AI project

## Testing
- `pytest`