### PR TITLE
feat: add evaluation dashboard page

### DIFF
--- a/pages/model_eval_dashboard.py
+++ b/pages/model_eval_dashboard.py
@@ -1,0 +1,20 @@
+import os
+import pandas as pd
+import streamlit as st
+from utilities.print_average import get_average
+
+st.title("Model Evaluation Dashboard")
+
+results_path = "data/eval_results.csv"
+
+if os.path.exists(results_path):
+    df = pd.read_csv(results_path)
+    st.subheader("Raw Evaluation Results")
+    st.dataframe(df)
+
+    st.subheader("Average Scores")
+    averages = get_average(results_path)
+    st.json(averages)
+else:
+    st.warning(f"Evaluation results file not found at {results_path}.")
+    st.info("Run evaluations to generate the results file.")


### PR DESCRIPTION
## Summary
- add Streamlit page to display evaluation results and average scores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4963c5d608325a7686f97559c2531